### PR TITLE
Fix meetup widget 404 being shown when uncoming

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -21,6 +21,11 @@ a {
   text-decoration: none;
 }
 
+/* Needed for twine.js */
+.hide {
+  display: none;
+}
+
 .site-header, .site-nav, .site-main, .site-footer {
   padding: 10px;
 }
@@ -74,7 +79,13 @@ a {
   text-align: center;
 }
 
+.description-widget {
+  padding-top: 70px;
+  padding-bottom: 70px;
+}
+
 .meetup-widget {
+  min-width: 46%;
   display: inline-block;
 }
 

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
       </a>
     </header>
     <main class="site-main">
-      <section class="site-widget">
+      <section class="site-widget description-widget">
         <blockquote class="site-quote">
           Videum Codeup är en samlingsplats för programmerare i Växjö-regionen.
           <br />
@@ -47,7 +47,7 @@
                 class="meetup-event-title"
                 data-bind="events.upcoming.name"></h2>
             </a>
-            <div data-bind-hide="!events.upcoming">
+            <div data-bind-show="!events.upcoming">
               <h2 class="meetup-event-title">
                 404 Not Found
               </h2>


### PR DESCRIPTION
The 404 was only meant to be shown when no upcoming meetup was found.